### PR TITLE
Use the regex from upstream marathon as-is

### DIFF
--- a/marathon/models/base.py
+++ b/marathon/models/base.py
@@ -54,7 +54,7 @@ class MarathonResource(MarathonObject):
 
 
 # See: https://github.com/mesosphere/marathon/blob/2a9d1d20ec2f1cfcc49fbb1c0e7348b26418ef38/src/main/scala/mesosphere/marathon/api/ModelValidation.scala#L224
-ID_PATTERN = re.compile(r'^(?:(?:[a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*(?:[a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$')
+ID_PATTERN = re.compile('^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$')
 
 
 def assert_valid_path(path):

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,12 +1,13 @@
 __author__ = 'kevinschoon@gmail.com'
 
+import os
 import random
 import uuid
 
 from marathon.models.app import MarathonApp, MarathonHealthCheck
 from marathon.models.container import MarathonContainer
 
-MARATHON_SERVER = 'http://ubuntu:8080'
+MARATHON_SERVER = os.getenv('MARATHON_SERVER', 'http://ubuntu:8080')
 MARATHON_CALLBACK_URL = 'http://192.168.99.1:9999'
 TIMESTAMP = '2015-05-29T23:05:37.715Z'
 SERVICE_PORT_RANGE = range(10000, 11000)


### PR DESCRIPTION
This fixes upstream
https://github.com/thefactory/marathon-python/issues/45
and 
https://github.com/thefactory/marathon-python/issues/41
