### PR TITLE
First pass at adding an itest framework

### DIFF
--- a/itests/docker-compose.yml
+++ b/itests/docker-compose.yml
@@ -1,0 +1,13 @@
+---
+zookeeper:
+  image: jplock/zookeeper
+  ports:
+    - 2181
+
+marathon:
+  image: mesosphere/marathon:v0.8.1
+  ports:
+    - 8080
+  links:
+    - zookeeper
+  command: '--master local --zk zk://zookeeper:2181/marathon'

--- a/itests/environment.py
+++ b/itests/environment.py
@@ -1,0 +1,21 @@
+import time
+
+from itest_utils import wait_for_marathon
+
+
+def before_all(context):
+    wait_for_marathon()
+
+
+def after_scenario(context, scenario):
+    """If a marathon client object exists in our context, delete any apps in Marathon and wait until they die."""
+    if context.client:
+        while True:
+            apps = context.client.list_apps()
+            if not apps:
+                break
+            for app in apps:
+                context.client.delete_app(app.id, force=True)
+            time.sleep(0.5)
+        while context.client.list_deployments():
+            time.sleep(0.5)

--- a/itests/itest_utils.py
+++ b/itests/itest_utils.py
@@ -1,0 +1,74 @@
+import errno
+from functools import wraps
+import os
+import signal
+import sys
+import threading
+import time
+
+import requests
+from compose.cli import command
+
+
+class TimeoutError(Exception):
+    pass
+
+def timeout(seconds=10, error_message=os.strerror(errno.ETIME)):
+    def decorator(func):
+        def _handle_timeout(signum, frame):
+            raise TimeoutError(error_message)
+
+        def wrapper(*args, **kwargs):
+            signal.signal(signal.SIGALRM, _handle_timeout)
+            signal.alarm(seconds)
+            try:
+                result = func(*args, **kwargs)
+            finally:
+                signal.alarm(0)
+            return result
+
+        return wraps(func)(wrapper)
+
+    return decorator
+
+
+@timeout(10)
+def wait_for_marathon():
+    """Blocks until marathon is up"""
+    marathon_service = get_service_connection_string('marathon')
+    while True:
+        print 'Connecting to marathon on %s' % marathon_service
+        try:
+            response = requests.get('http://%s/ping' % marathon_service, timeout=2)
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+        ):
+            time.sleep(2)
+            continue
+        if response.status_code == 200:
+            print "Marathon is up and running!"
+            break
+
+
+def get_compose_service(service_name):
+    """Returns a compose object for the service"""
+    cmd = command.Command()
+    project = cmd.get_project(cmd.get_config_path())
+    return project.get_service(service_name)
+
+
+def get_service_connection_string(service_name):
+    """Given a container name this function returns
+    the host and ephemeral port that you need to use to connect to. For example
+    if you are spinning up a 'web' container that inside listens on 80, this
+    function would return 0.0.0.0:23493 or whatever ephemeral forwarded port
+    it has from docker-compose"""
+    service_port = get_service_internal_port(service_name)
+    return get_compose_service(service_name).get_container().get_local_port(service_port)
+
+
+def get_service_internal_port(service_name):
+    """Gets the exposed port for service_name from docker-compose.yml. If there are
+    multiple ports. It returns the first one."""
+    return get_compose_service(service_name).options['ports'][0]

--- a/itests/marathon_python.feature
+++ b/itests/marathon_python.feature
@@ -1,0 +1,6 @@
+Feature: marathon-python can create and list marathon apps
+
+  Scenario: Trivial apps can be deployed
+    Given a working marathon instance
+    When we create a trivial new app
+    Then we should see it running via the marathon api

--- a/itests/steps/marathon_steps.py
+++ b/itests/steps/marathon_steps.py
@@ -1,0 +1,31 @@
+import sys
+import time
+
+import marathon
+from behave import given, when, then
+import mock
+
+from itest_utils import get_service_connection_string
+sys.path.append('../')
+
+
+@given('a working marathon instance')
+def working_marathon(context):
+    """Adds a working marathon client as context.client for the purposes of
+    interacting with it in the test."""
+    if not hasattr(context, 'client'):
+        marathon_connection_string = "http://%s" % \
+            get_service_connection_string('marathon')
+        context.client = marathon.MarathonClient(marathon_connection_string)
+
+
+@when(u'we create a trivial new app')
+def create_trivial_new_app(context):
+    context.client.create_app('myapp3', marathon.MarathonApp(cmd='sleep 100', mem=16, cpus=1))
+
+
+@then(u'we should see it running via the marathon api')
+def see_it_running(context):
+    print(context.client.list_apps())
+    assert context.client.get_app('myapp3')
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+usedevelop=True
+basepython = python2.7
+envlist = py
+
+[testenv:marathon_integration]
+basepython = python2.7
+skipsdist=True
+changedir=itests/
+deps =
+    docker-compose
+    behave
+    mock
+commands =
+    docker-compose pull
+    docker-compose up -d
+    behave {posargs}
+    docker-compose stop
+    docker-compose rm --force


### PR DESCRIPTION
This is a dupe of 
https://github.com/thefactory/marathon-python/pull/42
to move forward adding automated testing to catch regressions and api compatibility changes with Marathon.
