### PR TITLE
Added travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python: 2.7
+sudo: true
+install:
+  - pip install tox
+script:
+  - ./itests/install-marathon.sh
+  - /etc/init.d/zookeeper start
+  - marathon --master local --no-logger --hostname localhost &
+  - make itests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: itests
+itests:
+	tox -e itests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # marathon-python
 
+[![Build Status](https://travis-ci.org/Yelp/marathon-python.svg?branch=master)](https://travis-ci.org/Yelp/marathon-python)
+
 This is a Python library for interfacing with [Marathon](https://github.com/mesosphere/marathon) servers via Marathon's [REST API](https://mesosphere.github.io/marathon/docs/rest-api.html).
 
 #### Compatibility

--- a/itests/Dockerfile
+++ b/itests/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu-debootstrap:14.04
+RUN apt-get update && apt-get -y install sudo lsb-release
+
+# Setup
+ADD ./install-marathon.sh /root/install-marathon.sh
+RUN /root/install-marathon.sh
+
+EXPOSE 8080
+CMD /etc/init.d/zookeeper start && marathon --master local --no-logger

--- a/itests/docker-compose.yml
+++ b/itests/docker-compose.yml
@@ -1,13 +1,5 @@
 ---
-zookeeper:
-  image: jplock/zookeeper
-  ports:
-    - 2181
-
 marathon:
-  image: mesosphere/marathon:v0.8.1
+  build: .
   ports:
     - 8080
-  links:
-    - zookeeper
-  command: '--master local --zk zk://zookeeper:2181/marathon'

--- a/itests/install-marathon.sh
+++ b/itests/install-marathon.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -vx
+
+sudo apt-get update -q
+
+# Setup
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+CODENAME=$(lsb_release -cs)
+
+# Add the repository
+echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" | 
+  sudo tee /etc/apt/sources.list.d/mesosphere.list
+sudo apt-get -y update
+
+# Install packages
+sudo apt-get -y --force-yes install mesos marathon

--- a/itests/itest_utils.py
+++ b/itests/itest_utils.py
@@ -35,7 +35,7 @@ def timeout(seconds=10, error_message=os.strerror(errno.ETIME)):
 @timeout(10)
 def wait_for_marathon():
     """Blocks until marathon is up"""
-    marathon_service = get_service_connection_string('marathon')
+    marathon_service = get_marathon_connection_string()
     while True:
         print 'Connecting to marathon on %s' % marathon_service
         try:
@@ -58,14 +58,13 @@ def get_compose_service(service_name):
     return project.get_service(service_name)
 
 
-def get_service_connection_string(service_name):
-    """Given a container name this function returns
-    the host and ephemeral port that you need to use to connect to. For example
-    if you are spinning up a 'web' container that inside listens on 80, this
-    function would return 0.0.0.0:23493 or whatever ephemeral forwarded port
-    it has from docker-compose"""
-    service_port = get_service_internal_port(service_name)
-    return get_compose_service(service_name).get_container().get_local_port(service_port)
+def get_marathon_connection_string():
+    # only reliable way I can detect travis..
+    if '/travis/' in os.environ.get('PATH'):
+        return 'localhost:8080'
+    else:
+        service_port = get_service_internal_port('marathon')
+        return get_compose_service('marathon').get_container().get_local_port(service_port)
 
 
 def get_service_internal_port(service_name):

--- a/itests/steps/marathon_steps.py
+++ b/itests/steps/marathon_steps.py
@@ -5,7 +5,7 @@ import marathon
 from behave import given, when, then
 import mock
 
-from itest_utils import get_service_connection_string
+from itest_utils import get_marathon_connection_string
 sys.path.append('../')
 
 
@@ -15,7 +15,7 @@ def working_marathon(context):
     interacting with it in the test."""
     if not hasattr(context, 'client'):
         marathon_connection_string = "http://%s" % \
-            get_service_connection_string('marathon')
+            get_marathon_connection_string()
         context.client = marathon.MarathonClient(marathon_connection_string)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ usedevelop=True
 basepython = python2.7
 envlist = py
 
-[testenv:marathon_integration]
+[testenv:itests]
 basepython = python2.7
+whitelist_externals=/bin/bash
 skipsdist=True
 changedir=itests/
 deps =
@@ -12,8 +13,9 @@ deps =
     behave
     mock
 commands =
-    docker-compose pull
-    docker-compose up -d
+    /bin/bash -c set
+    /bin/bash -c "[ -n $TRAVIS ] || docker-compose pull"
+    /bin/bash -c "[ -n $TRAVIS ] || docker-compose up -d"
     behave {posargs}
-    docker-compose stop
-    docker-compose rm --force
+    /bin/bash -c "[ -n $TRAVIS ] || docker-compose stop"
+    /bin/bash -c "[ -n $TRAVIS ] || docker-compose rm --force"


### PR DESCRIPTION
This adds a travis config so we can tell in real time if our changes work or do not work against a real marathon.

I tried hard to do docker-in-travis, but in the end it was slow and there was not enough memory.

So instead I just have a install-marathon script that I run in travis natively if travis, or in docker (via compose). This gives a test run time of a <1m on metal and ~1m on travis with this minimalist test suite.

Either way we still use behave to do the actual tests.

cc @mrtyler and @EvanKrall 
