### PR TITLE
Added a matrix of marathon versions to test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+env:
+ - MARATHONVERSION: 0.8.1
+ - MARATHONVERSION: 0.8.2
+# Not supported yet
+# - MARATHONVERSION: 0.9.0
+
 language: python
 python: 2.7
 sudo: true
@@ -6,5 +12,5 @@ install:
 script:
   - ./itests/install-marathon.sh
   - /etc/init.d/zookeeper start
-  - marathon --master local --no-logger --hostname localhost &
+  - ./itests/start-marathon.sh &
   - make itests

--- a/itests/Dockerfile
+++ b/itests/Dockerfile
@@ -6,4 +6,5 @@ ADD ./install-marathon.sh /root/install-marathon.sh
 RUN /root/install-marathon.sh
 
 EXPOSE 8080
-CMD /etc/init.d/zookeeper start && marathon --master local --no-logger
+ADD ./start-marathon.sh /root/start-marathon.sh
+CMD /etc/init.d/zookeeper start && /root/start-marathon.sh

--- a/itests/install-marathon.sh
+++ b/itests/install-marathon.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -vx
 
+# Default version of marathon to test against if not
+# set already by travis
+MARATHONVERSION="${MARATHONVERSION:-0.8.2}"
+
 sudo apt-get update -q
 
 # Setup
@@ -14,4 +18,4 @@ echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" |
 sudo apt-get -y update
 
 # Install packages
-sudo apt-get -y --force-yes install mesos marathon
+sudo apt-get -y --force-yes install mesos marathon=$MARATHONVERSION*

--- a/itests/start-marathon.sh
+++ b/itests/start-marathon.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ $MARATHONVERSION != '0.8.1' ]]; then
+  LOGGER="--no-logger"
+else
+  LOGGER=""
+fi
+
+exec marathon --master local $LOGGER --hostname localhost

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
+passenv = TRAVIS
 usedevelop=True
 basepython = python2.7
 envlist = py
 
 [testenv:itests]
+passenv = TRAVIS
 basepython = python2.7
 whitelist_externals=/bin/bash
 skipsdist=True
@@ -13,9 +15,10 @@ deps =
     behave
     mock
 commands =
-    /bin/bash -c set
-    /bin/bash -c "[ -n $TRAVIS ] || docker-compose pull"
-    /bin/bash -c "[ -n $TRAVIS ] || docker-compose up -d"
+    /bin/bash -c "set | grep TRAVIS"
+    /bin/bash -c "[[ -n $TRAVIS ]] || docker-compose build"
+    /bin/bash -c "[[ -n $TRAVIS ]] || docker-compose pull"
+    /bin/bash -c "[[ -n $TRAVIS ]] || docker-compose up -d"
     behave {posargs}
-    /bin/bash -c "[ -n $TRAVIS ] || docker-compose stop"
-    /bin/bash -c "[ -n $TRAVIS ] || docker-compose rm --force"
+    /bin/bash -c "[[ -n $TRAVIS ]] || docker-compose stop"
+    /bin/bash -c "[[ -n $TRAVIS ]] || docker-compose rm --force"


### PR DESCRIPTION
Now that marathon 0.9.0 is release, we don't want to test against it till we are actually ready.
This adds a jenkins matrix so we can test only against the versions we currently support.

When we are ready to test against 0.9.0, we can uncomment out the line, see the tests fail, then add in the code to make them pass.
