### PR TITLE
Added complex app with healthchecks in the itests

### DIFF
--- a/itests/marathon_python.feature
+++ b/itests/marathon_python.feature
@@ -3,4 +3,9 @@ Feature: marathon-python can create and list marathon apps
   Scenario: Trivial apps can be deployed
     Given a working marathon instance
     When we create a trivial new app
-    Then we should see it running via the marathon api
+    Then we should see the trivial app running via the marathon api
+
+ Scenario: Complex apps can be deployed
+    Given a working marathon instance
+    When we create a complex new app
+    Then we should see the complex app running via the marathon api


### PR DESCRIPTION
Previously on the marathon 0.8.2 bindings upgrade it was incompatible with something about the docker or healthchecks json, I can't remember.

This make sure this does not happen again or that we can catch it in the future.
